### PR TITLE
Fix AI Search datasource name

### DIFF
--- a/deployment/bicep/modules/aiSearch/aiSearch-datasource.bicep
+++ b/deployment/bicep/modules/aiSearch/aiSearch-datasource.bicep
@@ -11,11 +11,12 @@ param storageAccountResourceId string
 @sys.description('Container name in the storage account.')
 param containerName string
 
+@sys.description('Data source name to be created in Azure AI Search service.')
+param dataSourceName string
+
 @sys.description('Managed Identity Id to be used for the deployment script')
 param managedIdentityId string
 
-// Variable to generate the datasource name
-var dataSourceName = '${containerName}-datasource'
 var jsonTemplate = loadFileAsBase64('../../../library/datasource_blob_template.json')
 
 resource aiSearchDataSource 'Microsoft.Resources/deploymentScripts@2023-08-01' = {

--- a/deployment/bicep/multimodal-ai.bicep
+++ b/deployment/bicep/multimodal-ai.bicep
@@ -92,6 +92,7 @@ var resourceNames = {
   cognitiveServices: '${prefixNormalized}-${locationNormalized}-cogsvc'
   storageAccount: take('${prefixNormalized}${locationNormalized}stg',23)
   aiSearchDeploymentScriptIdentity: '${prefixNormalized}-${locationNormalized}-aisearch-depscript-umi'
+  aiSearchDocsDataSourceName: '${storageAccountDocsContainerName}-datasource'
   appServicePlan: '${prefixNormalized}-${locationNormalized}-appserviceplan'
   functionApp: '${prefixNormalized}-${locationNormalized}-functionapp'
   functionAppUri: azureFunctionUri
@@ -309,6 +310,7 @@ module aiSearchDataSource 'modules/aiSearch/aiSearch-datasource.bicep' = {
   ]
   params: {
     location: location
+    dataSourceName: resourceNames.aiSearchDocsDataSourceName
     aiSearchEndpoint: last(split(aiSearch.outputs.searchResourceId, '/'))
     storageAccountResourceId: storageAccount.outputs.storageAccountId
     containerName: storageAccountDocsContainerName


### PR DESCRIPTION
fix to provide AI search data source name as parameter in the main bicep template file instead of generating it on a module.