### PR TITLE
streamlines image handling across all components

### DIFF
--- a/backend/core/imageshelper.py
+++ b/backend/core/imageshelper.py
@@ -20,7 +20,7 @@ class ImageURL(TypedDict, total=False):
 
 async def download_blob_as_base64(blob_container_client: ContainerClient, file_path: str) -> Optional[str]:
     base_name, _ = os.path.splitext(file_path)
-    image_filename = base_name + ".png"
+    image_filename = base_name + ".jpg"
     try:
         blob = await blob_container_client.get_blob_client(image_filename).download_blob()
         if not blob.properties:

--- a/backend/skills/pdf_text_image_merge_skill/function_app.py
+++ b/backend/skills/pdf_text_image_merge_skill/function_app.py
@@ -86,7 +86,7 @@ async def transform_value(value):
             name_part, _ = os.path.splitext(filename)
 
             enriched_page = {
-                "sourcepage": f"{name_part}-{split_page.page_num}.jpeg",
+                "sourcepage": f"{name_part}-{split_page.page_num}.jpg",
                 "sourcefile": filename,
                 "storageUrl": data["url"],
                 "content": split_page.text,

--- a/deployment/bicep/multimodal-ai.bicep
+++ b/deployment/bicep/multimodal-ai.bicep
@@ -60,9 +60,6 @@ param docIntelLocation string
 @sys.description('Specifies the container name to be created in the storage account for documents.')
 param storageAccountDocsContainerName string
 
-@sys.description('Specifies the container name to be created in the storage account for images.')
-param storageAccountImagesContainerName string
-
 @sys.description('Specifies the tags which will be applied to all resources.')
 param tags object = {}
 
@@ -377,7 +374,7 @@ module aiSearchSkillset 'modules/aiSearch/aiSearch-skillset.bicep' = {
     azureOpenAIEndpoint: 'https://${azureOpenAI.name}.openai.azure.com/'
     azureOpenAITextModelName: aoaiTextEmbeddingModelForAiSearch
     knowledgeStoreStorageResourceUri: 'ResourceId=${storageAccount.outputs.storageAccountId}'
-    knowledgeStoreStorageContainer: storageAccountImagesContainerName
+    knowledgeStoreStorageContainer: storageAccountDocsContainerName
     pdfMergeCustomSkillEndpoint: azureFunction.outputs.pdfTextImageMergeSkillEndpoint
     cognitiveServicesAccountId: azureCognitiveServices.outputs.cognitiveServicesAccountId
     managedIdentityId: aiSearchDeploymentScriptIdentity.outputs.managedIdentityId

--- a/deployment/bicep/multimodal-ai.bicepparam
+++ b/deployment/bicep/multimodal-ai.bicepparam
@@ -19,7 +19,6 @@ param cogsvcSku = 'S0'
 param cogsvcKind = 'CognitiveServices'
 
 param storageAccountDocsContainerName = 'docs'
-param storageAccountImagesContainerName = 'images'
 
 // Replace with real app
 param azureFunctionUri = ''

--- a/deployment/library/indexer_template.json
+++ b/deployment/library/indexer_template.json
@@ -13,8 +13,8 @@
     "base64EncodeKeys": null,
     "configuration": {
       "parsingMode": "default",
-      "excludedFileNameExtensions": "",
-      "indexedFileNameExtensions": "",
+      "excludedFileNameExtensions": ".png, .jpeg, .jpg",
+      "indexedFileNameExtensions": ".pdf",
       "failOnUnsupportedContentType": false,
       "failOnUnprocessableDocument": false,
       "indexStorageMetadataOnlyForOversizedDocuments": false,


### PR DESCRIPTION
- images are stored in the storage container where the backend expects them to be
- switched to using .*jpg as this is what the indexer atomically produces
- indexer is configured to process PDF files only