### PR TITLE
updates image citation style's height

### DIFF
--- a/frontend/src/components/AnalysisPanel/AnalysisPanel.module.css
+++ b/frontend/src/components/AnalysisPanel/AnalysisPanel.module.css
@@ -58,7 +58,7 @@
 }
 
 .citationImg {
-    height: 28.125rem;
+    height: 50rem;
     max-width: 100%;
     object-fit: contain;
 }


### PR DESCRIPTION
It is now possible to read the citation content:

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/c9a11a5d-f7eb-492c-b002-b5f48f9e1080">
