### PR TITLE
Fix images in citations

### DIFF
--- a/deployment/terraform/infra/service.tf
+++ b/deployment/terraform/infra/service.tf
@@ -90,12 +90,13 @@ module "keyvault" {
 
 
 module "storage" {
-  source                                    = "./modules/storage"
-  location                                  = var.location
-  tags                                      = local.tags
-  resource_group_name                       = azurerm_resource_group.resource_group.name
-  storage_account_name                      = var.storage_account_name != "" ? var.storage_account_name : substr("${local.abbrs.storageStorageAccounts}${local.resourceToken}", 0, 24)
-  storage_account_container_names           = [var.storage_container_name_content, var.storage_container_name_knowledgestore]
+  source               = "./modules/storage"
+  location             = var.location
+  tags                 = local.tags
+  resource_group_name  = azurerm_resource_group.resource_group.name
+  storage_account_name = var.storage_account_name != "" ? var.storage_account_name : substr("${local.abbrs.storageStorageAccounts}${local.resourceToken}", 0, 24)
+  #storage_account_container_names           = [var.storage_container_name_content, var.storage_container_name_knowledgestore]
+  storage_account_container_names           = [var.storage_container_name_content]
   storage_account_shared_access_key_enabled = false
   log_analytics_workspace_id                = var.log_analytics_workspace_id
   subnet_id                                 = azapi_resource.subnet_private_endpoints.id

--- a/deployment/terraform/infra/vars.tfvars
+++ b/deployment/terraform/infra/vars.tfvars
@@ -12,8 +12,9 @@ appservice_plan_sku   = "B3"
 search_service_sku    = "standard"
 semantic_search_sku   = "standard"
 
-storage_container_name_content        = "docs"
-storage_container_name_knowledgestore = "knowledgestore"
+storage_container_name_content = "docs"
+#storage_container_name_knowledgestore = "knowledgestore"
+storage_container_name_knowledgestore = "docs"
 
 azure_monitor_private_link_scope_name = ""
 ampls_scoped_service_appinsights      = ""


### PR DESCRIPTION
This PR fixes two items:

- [x] Images are not being sent to the multimodal LLM when submitting a prompt
- [x] Images are not being rendered as part of the citations in the web app

They were being stored in a container other than the expected one, hence they could not be retrieved by the web app. In future releases we will locate the images in a separa container than the docs container.

Closes #211 